### PR TITLE
security: remove hardcoded credentials and signing material

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,42 +13,45 @@ jobs:
       HEALTHCHECK_INTERVAL: 3
       HEALTHCHECK_RETRIES: 3
       SERVICES_TO_CHECK: "mysql redis"
+      MYSQL_DATABASE: coucommercedb
+      MYSQL_USER: app
 
     steps:
-      # --------------------------
-      #  체크아웃
-      # --------------------------
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # --------------------------
-      #  Docker 네트워크 생성 (옵션)
-      # --------------------------
       - name: Create Docker network
         run: docker network create cou-commerce-net || echo "Network already exists"
 
-      # --------------------------
-      #  MySQL 컨테이너 시작
-      # --------------------------
-      - name: Start MySQL service
+      - name: Generate ephemeral CI database credentials
+        shell: bash
         run: |
-          cd $GITHUB_WORKSPACE/infra/mysql
+          echo "MYSQL_PASSWORD=$(openssl rand -hex 16)" >> "$GITHUB_ENV"
+          echo "MYSQL_ROOT_PASSWORD=$(openssl rand -hex 16)" >> "$GITHUB_ENV"
+
+      - name: Start MySQL service
+        shell: bash
+        run: |
+          cd "$GITHUB_WORKSPACE/infra/mysql"
+          cat > .env <<EOF
+          MYSQL_DATABASE=$MYSQL_DATABASE
+          MYSQL_USER=$MYSQL_USER
+          MYSQL_PASSWORD=$MYSQL_PASSWORD
+          MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD
+          MYSQL_PORT=3306
+          EOF
           docker compose up -d
-          # MySQL 포트 확인
           echo "Waiting for MySQL port 3306..."
-          until mysqladmin ping -h 127.0.0.1 -u app -papp-secret --silent; do
+          until mysqladmin ping -h 127.0.0.1 -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
             echo "Waiting for MySQL..."
             sleep 2
           done
 
-      # --------------------------
-      #  Redis 컨테이너 시작
-      # --------------------------
       - name: Start Redis service
+        shell: bash
         run: |
-          cd $GITHUB_WORKSPACE/infra/redis
+          cd "$GITHUB_WORKSPACE/infra/redis"
           docker compose up -d
-          # Redis 헬스체크
           end=$((SECONDS + 30))
           while [ $SECONDS -lt $end ]; do
             if redis-cli -h 127.0.0.1 ping | grep -q PONG; then
@@ -59,9 +62,6 @@ jobs:
             sleep 2
           done
 
-      # --------------------------
-      #  JDK 및 Gradle 설정
-      # --------------------------
       - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
@@ -81,21 +81,16 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      # --------------------------
-      #  Gradle 빌드 & 테스트
-      # --------------------------
       - name: Build and Test with Gradle
-        env:
-          SPRING_PROFILES_ACTIVE: test
-          SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
-          SPRING_DATASOURCE_USERNAME: app
-          SPRING_DATASOURCE_PASSWORD: app-secret
-        run: ./gradlew build
+        shell: bash
+        run: |
+          SPRING_PROFILES_ACTIVE=test \
+          SPRING_DATASOURCE_URL='jdbc:mysql://127.0.0.1:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul' \
+          SPRING_DATASOURCE_USERNAME="$MYSQL_USER" \
+          SPRING_DATASOURCE_PASSWORD="$MYSQL_PASSWORD" \
+          ./gradlew build
 
-      # --------------------------
-      #  보고서 업로드
-      # --------------------------
-      - name: Upload Checkstyle Report on failure
+      - name: Upload Checkstyle Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -103,7 +98,7 @@ jobs:
           path: build/reports/checkstyle/*.html
           if-no-files-found: warn
 
-      - name: Upload Test Report on failure
+      - name: Upload Test Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -111,11 +106,8 @@ jobs:
           path: build/reports/tests/test/
           if-no-files-found: warn
 
-      # --------------------------
-      #  컨테이너 종료
-      # --------------------------
       - name: Tear down MySQL and Redis
         if: always()
         run: |
-          cd $GITHUB_WORKSPACE/infra/mysql && docker compose down
-          cd $GITHUB_WORKSPACE/infra/redis && docker compose down
+          cd "$GITHUB_WORKSPACE/infra/mysql" && docker compose down
+          cd "$GITHUB_WORKSPACE/infra/redis" && docker compose down

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,15 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local environment / secrets ###
+.env
+.env.*
+**/.env
+**/.env.*
+!.env.example
+!**/.env.example
+
 # Compiled class file
 *.class
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Cou-commerce
-1차 프로젝트 : 협업을 위한 실시간 버그 해결 프로젝트
+
+협업을 통해 이커머스 백엔드의 장바구니, 주문, 결제, 인증·인가와 운영 환경을 구현한 팀 프로젝트입니다.
+
+## 로컬 실행 전 필수 환경 변수
+
+개발 프로필은 저장소에 비밀번호나 JWT 서명 키를 저장하지 않습니다. 실행 전에 다음 환경 변수를 설정해야 합니다.
+
+```bash
+export SPRING_DATASOURCE_URL='jdbc:mysql://localhost:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8'
+export SPRING_DATASOURCE_USERNAME='app'
+export SPRING_DATASOURCE_PASSWORD='<로컬 데이터베이스 비밀번호>'
+export JWT_SECRET="$(openssl rand -base64 64)"
+```
+
+MySQL과 Redis의 실행 절차는 `infra/README.md`를 참고합니다. 실제 비밀번호와 서명 키가 포함된 `.env` 또는 개인 설정 파일은 커밋하지 않습니다.
+
+## 테스트
+
+테스트 프로필도 데이터베이스 비밀번호를 환경 변수로 받습니다.
+
+```bash
+SPRING_PROFILES_ACTIVE=test \
+SPRING_DATASOURCE_PASSWORD='<로컬 테스트 데이터베이스 비밀번호>' \
+./gradlew test
+```
+
+GitHub Actions는 PR마다 임시 데이터베이스 비밀번호를 생성해 사용합니다.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,56 +1,50 @@
-# 프로젝트에서의 역할(로컬 개발 아키텍처)
-```
-[App 컨테이너]  ──(cou-commerce-net)──>  [mysql:8.4 LTS]
-   │
-   └────────(cou-commerce-net)──>  [redis:7.4]
-   ```
+# 로컬 개발 인프라
 
-##  의도
-- DB와 캐시를 각각 별도 Compose 스택으로 독립 실행하면서, 공통 외부 네트워크(cou-commerce-net)로 애플리케이션이 접근하도록 설계
+애플리케이션, MySQL, Redis를 각각 독립된 Compose 스택으로 실행하고 공통 외부 네트워크 `cou-commerce-net`으로 연결합니다.
 
-## 이점
-- 서비스별 lifecycle 분리(DB만 재시작해도 App 영향 최소화)
-- 스택 교체/확장(예: Redis→클러스터) 용이
-- 팀별 책임 경계 명확
+## 1. 공통 네트워크 생성
 
-## 핵심 규칙
-- 외부 네트워크는 미리 생성해두고(docker network create cucommerce-net), 각 Compose에서 networks: { cucommerce-net: { external: true } }로 공유합니다.
----
-# 실행 방법
-## 공통 준비(한번만 실행)
-```
+```bash
 docker network create cou-commerce-net
 ```
-- App의 연결 호스트명은 각 서비스명(예: mysql, redis)을 그대로 사용합니다. Compose 네트워크에서 서비스명이 곧 DNS 이름
 
----
-# 인프라 스택
-## A. MySQL 스택 (권장: 8.4 LTS)
-- 이미지: mysql:8.4 ← 커뮤니티 LTS 릴리스(장기 지원) 라인
-- 포트(기본): 3306 
-- 지속 데이터: mysql-data 볼륨(/var/lib/mysql)
+이미 생성된 경우의 오류는 무시해도 됩니다.
 
-### 권장 옵션
-- 문자셋/콜레이션: utf8mb4 / utf8mb4_0900_ai_ci 
-- 타임존: Asia/Seoul 
-- 적정 max_connections(개발 200 정도)
-- 예시 연결 문자열 (Spring)
-    ```
-    jdbc:mysql://mysql:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
-    username=app
-    password=app-secret
-    ```
-- 헬스체크: mysqladmin ping 활용해 의존 서비스가 준비된 뒤 App 기동
+## 2. MySQL 환경 변수 준비
 
-## B. Redis 스택 (권장: 7.4 계열)
-
-- 이미지: redis:7.4 (공식 Docker Hub)
-- 포트(기본): 6379
-- 지속 데이터: redis-data 볼륨(/data), AOF 모드(--appendonly yes)
-- 예시 연결 URI: redis://redis:6379
-- 헬스체크: redis-cli ping
-
-### 특징
+```bash
+cd infra/mysql
+cp .env.example .env
 ```
-두 스택은 서로 별도 docker-compose.yml에 존재하며, 둘 다 cou-commerce-net에 참여하므로 App은 mysql, redis라는 호스트명으로 접근합니다. (다중 Compose 프로젝트 간 통신의 정석 패턴)
-``` 
+
+복사한 `.env`에서 데이터베이스 사용자 비밀번호와 root 비밀번호를 서로 다른 로컬 전용 값으로 변경합니다. `.env`는 Git 추적 대상이 아니며 커밋하거나 공유하지 않습니다.
+
+## 3. MySQL 실행
+
+```bash
+docker compose up -d
+```
+
+기본 데이터베이스명과 사용자명은 `.env`에서 변경할 수 있습니다. 애플리케이션에는 동일한 접속 정보를 환경 변수로 전달합니다.
+
+```bash
+export SPRING_DATASOURCE_URL='jdbc:mysql://localhost:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8'
+export SPRING_DATASOURCE_USERNAME='app'
+export SPRING_DATASOURCE_PASSWORD='<infra/mysql/.env에 설정한 값>'
+```
+
+## 4. Redis 실행
+
+```bash
+cd infra/redis
+docker compose up -d
+```
+
+애플리케이션 컨테이너에서 접근할 때는 Compose 서비스명인 `mysql`, `redis`를 호스트명으로 사용하고, 로컬에서 직접 실행할 때는 `localhost`를 사용합니다.
+
+## 보안 원칙
+
+- 실제 비밀번호, JWT 서명 키, 운영 접속 정보는 저장소에 커밋하지 않습니다.
+- 로컬 비밀번호와 운영 비밀번호를 재사용하지 않습니다.
+- 노출이 의심되는 값은 파일 삭제보다 먼저 폐기·재발급합니다.
+- 예제 파일에는 실제 값이 아니라 교체가 필요한 자리표시자만 둡니다.

--- a/infra/mysql/.env
+++ b/infra/mysql/.env
@@ -1,5 +1,0 @@
-# MySQL
-SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
-SPRING_DATASOURCE_USERNAME=app
-SPRING_DATASOURCE_PASSWORD=app-secret
-

--- a/infra/mysql/.env.example
+++ b/infra/mysql/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and replace every placeholder before starting MySQL.
+MYSQL_DATABASE=coucommercedb
+MYSQL_USER=app
+MYSQL_PASSWORD=replace-with-a-local-password
+MYSQL_ROOT_PASSWORD=replace-with-a-different-local-root-password
+MYSQL_PORT=3306

--- a/infra/mysql/docker-compose.yml
+++ b/infra/mysql/docker-compose.yml
@@ -2,13 +2,13 @@ name: cou-commerce-mysql
 
 services:
   mysql:
-    image: mysql:8.4        # LTS(장기지원) 라인 권장
-    container_name: mysql   # 공유 네트워크에서 호스트명으로 사용 (개발 편의)
+    image: mysql:8.4
+    container_name: mysql
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-coucommercedb}
       MYSQL_USER: ${MYSQL_USER:-app}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-app-secret}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root-secret}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?Set MYSQL_PASSWORD in infra/mysql/.env}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD in infra/mysql/.env}
       TZ: Asia/Seoul
     command:
       - --character-set-server=utf8mb4

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,20 +1,20 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: app
-    password: app-secret
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${SPRING_DATASOURCE_USERNAME:app}
+    password: ${SPRING_DATASOURCE_PASSWORD}
 
   data:
     redis:
-      host: localhost
-      port: 6379
-      timeout: 2000ms
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: ${REDIS_TIMEOUT:2000ms}
 
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
 
 jwt:
-  secret: rYc3wyeAhG3i5pHYlMKLy23xAT7wxlxWEgRIw891deXjDobnv+ayPwS5qlxtjcb1M5Eb9T3WKfAD3Rn/eV5tBA==
-  refresh-token-expiration-time: 360000
-  access-token-expiration-time: 3600000
+  secret: ${JWT_SECRET}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:360000}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:3600000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,11 +16,6 @@ spring:
     hibernate:
       ddl-auto: update
 
-  security:
-    user:
-      name: admin
-      password: password
-
   jackson:
     deserialization:
       fail-on-unknown-properties: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,41 +1,31 @@
 spring:
-  # --- Database (MySQL on Docker) ---
   datasource:
-    url: jdbc:mysql://localhost:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: app
-    password: app-secret
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/coucommercedb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${SPRING_DATASOURCE_USERNAME:app}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-  # --- JPA ---
   jpa:
     hibernate:
-      # 테스트 실행 시 스키마를 모두 지우고 다시 생성하여 독립성을 보장합니다.
       ddl-auto: create-drop
     properties:
       hibernate:
-        # MySQL 8 버전용 방언을 사용합니다.
         dialect: org.hibernate.dialect.MySQLDialect
-    # SQL 쿼리를 보고 싶을 경우, 아래 값을 true로 변경하세요.
     show-sql: false
 
-  # --- Redis (Redis on Docker) ---
   data:
     redis:
-      host: localhost
-      port: 6379
-      timeout: 2000ms
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: ${REDIS_TIMEOUT:2000ms}
 
-# --- Spring Core Settings ---
   main:
     allow-bean-definition-overriding: true
 
-# --- Logging Settings ---
 logging:
   level:
     root: INFO
 
-# --- Etc. ---
-# 테스트 환경에서 Swagger UI 비활성화
 springdoc:
   api-docs:
     enabled: false


### PR DESCRIPTION
## Summary
- replace committed development and test credentials with environment-variable configuration
- remove the tracked local environment file and keep only a placeholder example
- generate ephemeral database credentials during CI
- add ignore rules and secure local-run documentation

## Security note
Any previously committed value that was ever used outside an isolated local or test environment must be treated as compromised and rotated before reuse. This change removes the values from the current code line only; it does not purge Git history, pull-request diffs, forks, or caches.

## Validation
The pull-request CI workflow completed successfully.